### PR TITLE
Update defaultAddons.txt to force client configuration settings to be the same as the server, changed auto-add-fries to yes for fast roping

### DIFF
--- a/default/defaultAddons.txt
+++ b/default/defaultAddons.txt
@@ -1,13 +1,13 @@
 // ACE Advanced Ballistics
-ace_advanced_ballistics_ammoTemperatureEnabled = true;
-ace_advanced_ballistics_barrelLengthInfluenceEnabled = true;
-ace_advanced_ballistics_bulletTraceEnabled = true;
+force ace_advanced_ballistics_ammoTemperatureEnabled = true;
+force ace_advanced_ballistics_barrelLengthInfluenceEnabled = true;
+force ace_advanced_ballistics_bulletTraceEnabled = true;
 force ace_advanced_ballistics_enabled = true;
-ace_advanced_ballistics_muzzleVelocityVariationEnabled = true;
-ace_advanced_ballistics_simulationInterval = 0.05;
+force ace_advanced_ballistics_muzzleVelocityVariationEnabled = true;
+force ace_advanced_ballistics_simulationInterval = 0.05;
 
 // ACE Advanced Fatigue
-ace_advanced_fatigue_enabled = true;
+force ace_advanced_fatigue_enabled = true;
 ace_advanced_fatigue_enableStaminaBar = true;
 ace_advanced_fatigue_fadeStaminaBar = true;
 force ace_advanced_fatigue_loadFactor = 0.7;
@@ -16,24 +16,24 @@ force ace_advanced_fatigue_recoveryFactor = 1.4904;
 force ace_advanced_fatigue_terrainGradientFactor = 0.871643;
 
 // ACE Advanced Throwing
-ace_advanced_throwing_enabled = true;
-ace_advanced_throwing_enablePickUp = true;
-ace_advanced_throwing_enablePickUpAttached = true;
+force ace_advanced_throwing_enabled = true;
+force ace_advanced_throwing_enablePickUp = true;
+force ace_advanced_throwing_enablePickUpAttached = true;
 ace_advanced_throwing_enableTempWindInfo = true;
 ace_advanced_throwing_showMouseControls = true;
 ace_advanced_throwing_showThrowArc = true;
 
 // ACE Advanced Vehicle Damage
-ace_vehicle_damage_enableCarDamage = false;
-ace_vehicle_damage_enabled = false;
-ace_vehicle_damage_removeAmmoDuringCookoff = true;
+force ace_vehicle_damage_enableCarDamage = false;
+force ace_vehicle_damage_enabled = false;
+force ace_vehicle_damage_removeAmmoDuringCookoff = true;
 
 // ACE AI
-ace_ai_assignNVG = false;
+force ace_ai_assignNVG = false;
 
 // ACE Arsenal
-ace_arsenal_allowDefaultLoadouts = true;
-ace_arsenal_allowSharedLoadouts = true;
+force ace_arsenal_allowDefaultLoadouts = true;
+force ace_arsenal_allowSharedLoadouts = true;
 ace_arsenal_camInverted = false;
 ace_arsenal_defaultToFavorites = false;
 force ace_arsenal_enableIdentityTabs = false;
@@ -41,23 +41,23 @@ ace_arsenal_enableModIcons = true;
 ace_arsenal_EnableRPTLog = false;
 ace_arsenal_favoritesColor = [0.9,0.875,0.6];
 ace_arsenal_fontHeight = 4.5;
-ace_arsenal_loadoutsSaveFace = false;
-ace_arsenal_loadoutsSaveInsignia = true;
-ace_arsenal_loadoutsSaveVoice = false;
+force ace_arsenal_loadoutsSaveFace = false;
+force ace_arsenal_loadoutsSaveInsignia = false;
+force ace_arsenal_loadoutsSaveVoice = false;
 
 // ACE Artillery
-ace_artillerytables_advancedCorrections = false;
-ace_artillerytables_disableArtilleryComputer = false;
-ace_mk6mortar_airResistanceEnabled = false;
-ace_mk6mortar_allowCompass = true;
-ace_mk6mortar_allowComputerRangefinder = true;
-ace_mk6mortar_useAmmoHandling = false;
+force ace_artillerytables_advancedCorrections = false;
+force ace_artillerytables_disableArtilleryComputer = false;
+force ace_mk6mortar_airResistanceEnabled = false;
+force ace_mk6mortar_allowCompass = true;
+force ace_mk6mortar_allowComputerRangefinder = true;
+force ace_mk6mortar_useAmmoHandling = false;
 
 // ACE Captives
-ace_captives_allowHandcuffOwnSide = true;
-ace_captives_allowSurrender = true;
-ace_captives_requireSurrender = 1;
-ace_captives_requireSurrenderAi = false;
+force ace_captives_allowHandcuffOwnSide = true;
+force ace_captives_allowSurrender = true;
+force ace_captives_requireSurrender = 1;
+force ace_captives_requireSurrenderAi = false;
 
 // ACE Casings
 ace_casings_enabled = true;
@@ -65,9 +65,9 @@ ace_casings_maxCasings = 250;
 
 // ACE Common
 ace_common_allowFadeMusic = true;
-ace_common_checkPBOsAction = 0;
-ace_common_checkPBOsCheckAll = false;
-ace_common_checkPBOsWhitelist = "[]";
+force ace_common_checkPBOsAction = 0;
+force ace_common_checkPBOsCheckAll = false;
+force ace_common_checkPBOsWhitelist = "[]";
 ace_common_deployedSwayFactor = 1;
 ace_common_displayTextColor = [0,0,0,0.1];
 ace_common_displayTextFontColor = [1,1,1,1];
@@ -89,58 +89,58 @@ force ace_cookoff_enableFire = true;
 force ace_cookoff_probabilityCoef = 1;
 
 // ACE Crew Served Weapons
-ace_csw_ammoHandling = 2;
-ace_csw_defaultAssemblyMode = false;
+force ace_csw_ammoHandling = 2;
+force ace_csw_defaultAssemblyMode = false;
 ace_csw_dragAfterDeploy = false;
-ace_csw_handleExtraMagazines = true;
-ace_csw_handleExtraMagazinesType = 0;
-ace_csw_progressBarTimeCoefficent = 1;
+force ace_csw_handleExtraMagazines = true;
+force ace_csw_handleExtraMagazinesType = 0;
+force ace_csw_progressBarTimeCoefficent = 1;
 
 // ACE Dragging
-ace_dragging_allowRunWithLightweight = true;
-ace_dragging_dragAndFire = true;
-ace_dragging_skipContainerWeight = false;
-ace_dragging_weightCoefficient = 1;
+force ace_dragging_allowRunWithLightweight = true;
+force ace_dragging_dragAndFire = true;
+force ace_dragging_skipContainerWeight = false;
+force ace_dragging_weightCoefficient = 1;
 
 // ACE Explosives
-ace_explosives_customTimerDefault = 30;
-ace_explosives_customTimerMax = 900;
-ace_explosives_customTimerMin = 5;
-ace_explosives_explodeOnDefuse = true;
-ace_explosives_punishNonSpecialists = true;
-ace_explosives_requireSpecialist = false;
+force ace_explosives_customTimerDefault = 30;
+force ace_explosives_customTimerMax = 900;
+force ace_explosives_customTimerMin = 5;
+force ace_explosives_explodeOnDefuse = true;
+force ace_explosives_punishNonSpecialists = true;
+force ace_explosives_requireSpecialist = false;
 
 // ACE Field Rations
-acex_field_rations_affectAdvancedFatigue = true;
-acex_field_rations_enabled = false;
+force acex_field_rations_affectAdvancedFatigue = false;
+force acex_field_rations_enabled = false;
 acex_field_rations_hudShowLevel = 0;
 acex_field_rations_hudTransparency = -1;
 acex_field_rations_hudType = 0;
-acex_field_rations_hungerSatiated = 1;
-acex_field_rations_terrainObjectActions = true;
-acex_field_rations_thirstQuenched = 1;
-acex_field_rations_timeWithoutFood = 2;
-acex_field_rations_timeWithoutWater = 2;
-acex_field_rations_waterSourceActions = 2;
+force acex_field_rations_hungerSatiated = 1;
+force acex_field_rations_terrainObjectActions = false;
+force acex_field_rations_thirstQuenched = 1;
+force acex_field_rations_timeWithoutFood = 2;
+force acex_field_rations_timeWithoutWater = 2;
+force acex_field_rations_waterSourceActions = 2;
 
 // ACE Fire
-ace_fire_dropWeapon = 1;
+force ace_fire_dropWeapon = 0;
 force ace_fire_enabled = false;
-ace_fire_enableFlare = false;
-ace_fire_enableScreams = true;
+force ace_fire_enableFlare = false;
+force ace_fire_enableScreams = false;
 
 // ACE Fortify
-ace_fortify_markObjectsOnMap = 1;
-ace_fortify_timeCostCoefficient = 1;
-ace_fortify_timeMin = 1.5;
-acex_fortify_settingHint = 2;
+force ace_fortify_markObjectsOnMap = 1;
+force ace_fortify_timeCostCoefficient = 1;
+force ace_fortify_timeMin = 1.5;
+force acex_fortify_settingHint = 0;
 
 // ACE Fragmentation Simulation
-ace_frag_enabled = true;
-ace_frag_maxTrack = 10;
-ace_frag_maxTrackPerFrame = 10;
-ace_frag_reflectionsEnabled = false;
-ace_frag_spallEnabled = false;
+force ace_frag_enabled = true;
+force ace_frag_maxTrack = 10;
+force ace_frag_maxTrackPerFrame = 10;
+force ace_frag_reflectionsEnabled = false;
+force ace_frag_spallEnabled = false;
 
 // ACE G-Forces
 ace_gforces_coef = 1;
@@ -152,30 +152,30 @@ ace_goggles_showClearGlasses = false;
 ace_goggles_showInThirdPerson = false;
 
 // ACE Grenades
-ace_grenades_convertExplosives = true;
+force ace_grenades_convertExplosives = true;
 
 // ACE Headless
-acex_headless_delay = 15;
-acex_headless_enabled = false;
-acex_headless_endMission = 0;
-acex_headless_log = false;
-acex_headless_transferLoadout = 0;
+force acex_headless_delay = 15;
+force acex_headless_enabled = false;
+force acex_headless_endMission = 0;
+force acex_headless_log = false;
+force acex_headless_transferLoadout = 0;
 
 // ACE Hearing
 force ace_hearing_autoAddEarplugsToUnits = false;
-ace_hearing_disableEarRinging = false;
-ace_hearing_earplugsVolume = 0.5;
+force ace_hearing_disableEarRinging = false;
+force ace_hearing_earplugsVolume = 0.5;
 force ace_hearing_enableCombatDeafness = false;
 force ace_hearing_enabledForZeusUnits = false;
-ace_hearing_unconsciousnessVolume = 0.4;
+force ace_hearing_unconsciousnessVolume = 0.4;
 
 // ACE Interaction
 force ace_interaction_disableNegativeRating = true;
-ace_interaction_enableGroupRenaming = true;
-ace_interaction_enableMagazinePassing = true;
+force ace_interaction_enableGroupRenaming = false;
+force ace_interaction_enableMagazinePassing = true;
 force ace_interaction_enableTeamManagement = true;
-ace_interaction_enableWeaponAttachments = true;
-ace_interaction_interactWithTerrainObjects = false;
+force ace_interaction_enableWeaponAttachments = true;
+force ace_interaction_interactWithTerrainObjects = false;
 
 // ACE Interaction Menu
 ace_gestures_showOnInteractionMenu = 2;
@@ -200,25 +200,25 @@ ace_interact_menu_useListMenu = true;
 ace_interact_menu_useListMenuSelf = false;
 
 // ACE Kill Tracker
-ace_killtracker_trackAI = true;
+force ace_killtracker_trackAI = true;
 
 // ACE Logistics
 ace_cargo_carryAfterUnload = true;
-ace_cargo_enable = true;
-ace_cargo_enableDeploy = true;
-ace_cargo_enableRename = true;
-ace_cargo_loadTimeCoefficient = 5;
-ace_cargo_openAfterUnload = 0;
-ace_cargo_paradropTimeCoefficent = 2.5;
-ace_rearm_distance = 20;
-ace_rearm_enabled = true;
-ace_rearm_level = 0;
-ace_rearm_supply = 0;
-ace_refuel_cargoRate = 10;
+force ace_cargo_enable = true;
+force ace_cargo_enableDeploy = true;
+force ace_cargo_enableRename = true;
+force ace_cargo_loadTimeCoefficient = 5;
+force ace_cargo_openAfterUnload = 0;
+force ace_cargo_paradropTimeCoefficent = 2.5;
+force ace_rearm_distance = 20;
+force ace_rearm_enabled = true;
+force ace_rearm_level = 0;
+force ace_rearm_supply = 0;
+force ace_refuel_cargoRate = 10;
 force ace_refuel_hoseLength = 14;
 force ace_refuel_progressDuration = 1;
-ace_refuel_rate = 1;
-ace_towing_addRopeToVehicleInventory = true;
+force ace_refuel_rate = 1;
+force ace_towing_addRopeToVehicleInventory = true;
 
 // ACE Magazine Repack
 ace_magazinerepack_repackAnimation = true;
@@ -228,36 +228,36 @@ ace_magazinerepack_timePerBeltLink = 8;
 ace_magazinerepack_timePerMagazine = 2;
 
 // ACE Map
-ace_map_BFT_Enabled = false;
-ace_map_BFT_HideAiGroups = false;
-ace_map_BFT_Interval = 1;
-ace_map_BFT_ShowPlayerNames = false;
-ace_map_DefaultChannel = -1;
-ace_map_mapGlow = true;
-ace_map_mapIllumination = true;
-ace_map_mapLimitZoom = false;
-ace_map_mapShake = true;
-ace_map_mapShowCursorCoordinates = false;
-ace_markers_moveRestriction = 0;
-ace_markers_timestampEnabled = true;
-ace_markers_timestampFormat = "HH:MM";
-ace_markers_timestampHourFormat = 24;
-ace_markers_timestampTimezone = 0;
-ace_markers_TimestampUTCMinutesOffset = 0;
-ace_markers_timestampUTCOffset = 0;
+force ace_map_BFT_Enabled = false;
+force ace_map_BFT_HideAiGroups = false;
+force ace_map_BFT_Interval = 0;
+force ace_map_BFT_ShowPlayerNames = false;
+force ace_map_DefaultChannel = 1;
+force ace_map_mapGlow = true;
+force ace_map_mapIllumination = true;
+force ace_map_mapLimitZoom = false;
+force ace_map_mapShake = true;
+force ace_map_mapShowCursorCoordinates = false;
+force ace_markers_moveRestriction = 0;
+force ace_markers_timestampEnabled = true;
+force ace_markers_timestampFormat = "HH:MM";
+force ace_markers_timestampHourFormat = 24;
+force ace_markers_timestampTimezone = 0;
+force ace_markers_TimestampUTCMinutesOffset = 0;
+force ace_markers_timestampUTCOffset = 0;
 
 // ACE Map Gestures
-ace_map_gestures_allowCurator = true;
-ace_map_gestures_allowSpectator = true;
-ace_map_gestures_briefingMode = 0;
+force ace_map_gestures_allowCurator = false;
+force ace_map_gestures_allowSpectator = false;
+force ace_map_gestures_briefingMode = 0;
 ace_map_gestures_defaultColor = [1,0.88,0,0.7];
 ace_map_gestures_defaultLeadColor = [1,0.88,0,0.95];
-ace_map_gestures_enabled = true;
-ace_map_gestures_interval = 0.03;
-ace_map_gestures_maxRange = 7;
-ace_map_gestures_maxRangeCamera = 14;
+force ace_map_gestures_enabled = true;
+force ace_map_gestures_interval = 0.03;
+force ace_map_gestures_maxRange = 7;
+force ace_map_gestures_maxRangeCamera = 14;
 ace_map_gestures_nameTextColor = [0.2,0.2,0.2,0.3];
-ace_map_gestures_onlyShowFriendlys = false;
+force ace_map_gestures_onlyShowFriendlys = true;
 
 // ACE Map Tools
 ace_maptools_drawStraightLines = true;
@@ -337,9 +337,9 @@ force ace_medical_treatment_woundStitchTime = 5;
 force ace_medical_vitals_simulateSpO2 = false;
 
 // ACE Medical Interface
-ace_medical_feedback_bloodVolumeEffectType = 0;
+force ace_medical_feedback_bloodVolumeEffectType = 0;
 ace_medical_feedback_enableHUDIndicators = true;
-ace_medical_feedback_painEffectType = 0;
+force ace_medical_feedback_painEffectType = 0;
 ace_medical_gui_bloodLossColor_0 = [1,1,1,1];
 ace_medical_gui_bloodLossColor_1 = [1,0.95,0.64,1];
 ace_medical_gui_bloodLossColor_2 = [1,0.87,0.46,1];
@@ -370,9 +370,9 @@ ace_medical_gui_openAfterTreatment = true;
 ace_medical_gui_peekMedicalInfoReleaseDelay = 1;
 ace_medical_gui_peekMedicalOnHit = false;
 ace_medical_gui_peekMedicalOnHitDuration = 1;
-ace_medical_gui_showBleeding = 2;
-ace_medical_gui_showBloodlossEntry = true;
-ace_medical_gui_showDamageEntry = false;
+force ace_medical_gui_showBleeding = 2;
+force ace_medical_gui_showBloodlossEntry = true;
+force ace_medical_gui_showDamageEntry = false;
 ace_medical_gui_tourniquetWarning = false;
 
 // ACE Name Tags
@@ -385,8 +385,8 @@ ace_nametags_nametagColorRed = [1,0.67,0.67,1];
 ace_nametags_nametagColorYellow = [1,1,0.67,1];
 force ace_nametags_playerNamesMaxAlpha = 0.701618;
 ace_nametags_playerNamesViewDistance = 5;
-ace_nametags_showCursorTagForVehicles = false;
-ace_nametags_showNamesForAI = false;
+force ace_nametags_showCursorTagForVehicles = false;
+force ace_nametags_showNamesForAI = false;
 ace_nametags_showPlayerNames = 1;
 force ace_nametags_showPlayerRanks = false;
 ace_nametags_showSoundWaves = 1;
@@ -394,29 +394,29 @@ ace_nametags_showVehicleCrewInfo = true;
 ace_nametags_tagSize = 2;
 
 // ACE Nightvision
-ace_nightvision_aimDownSightsBlur = 1;
-ace_nightvision_disableNVGsWithSights = false;
-ace_nightvision_effectScaling = 1;
-ace_nightvision_fogScaling = 1;
-ace_nightvision_noiseScaling = 1;
-ace_nightvision_shutterEffects = true;
+force ace_nightvision_aimDownSightsBlur = 1;
+force ace_nightvision_disableNVGsWithSights = false;
+force ace_nightvision_effectScaling = 1;
+force ace_nightvision_fogScaling = 1;
+force ace_nightvision_noiseScaling = 1;
+force ace_nightvision_shutterEffects = true;
 
 // ACE Overheating
 force ace_overheating_cookoffCoef = 0;
-ace_overheating_coolingCoef = 1;
-ace_overheating_displayTextOnJam = true;
-ace_overheating_enabled = true;
-ace_overheating_heatCoef = 1;
-ace_overheating_jamChanceCoef = 1;
-ace_overheating_overheatingDispersion = true;
-ace_overheating_overheatingRateOfFire = true;
-ace_overheating_particleEffectsAndDispersionDistance = 3000;
-ace_overheating_showParticleEffects = true;
-ace_overheating_showParticleEffectsForEveryone = false;
-ace_overheating_suppressorCoef = 1;
-ace_overheating_unJamFailChance = 0.1;
-ace_overheating_unJamOnreload = false;
-ace_overheating_unJamOnSwapBarrel = false;
+force ace_overheating_coolingCoef = 1;
+force ace_overheating_displayTextOnJam = true;
+force ace_overheating_enabled = false;
+force ace_overheating_heatCoef = 1;
+force ace_overheating_jamChanceCoef = 0.5;
+force ace_overheating_overheatingDispersion = true;
+force ace_overheating_overheatingRateOfFire = true;
+force ace_overheating_particleEffectsAndDispersionDistance = 3000;
+force ace_overheating_showParticleEffects = true;
+force ace_overheating_showParticleEffectsForEveryone = false;
+force ace_overheating_suppressorCoef = 1;
+force ace_overheating_unJamFailChance = 0.1;
+force ace_overheating_unJamOnreload = false;
+force ace_overheating_unJamOnSwapBarrel = false;
 
 // ACE Pointing
 force ace_finger_enabled = true;
@@ -443,39 +443,39 @@ ace_quickmount_priority = 0;
 ace_quickmount_speed = 18;
 
 // ACE Repair
-ace_repair_addSpareParts = true;
-ace_repair_autoShutOffEngineWhenStartingRepair = false;
-ace_repair_consumeItem_toolKit = 0;
-ace_repair_displayTextOnRepair = true;
-ace_repair_enabled = true;
+force ace_repair_addSpareParts = false;
+force ace_repair_autoShutOffEngineWhenStartingRepair = false;
+force ace_repair_consumeItem_toolKit = 0;
+force ace_repair_displayTextOnRepair = true;
+force ace_repair_enabled = true;
 force ace_repair_engineerSetting_fullRepair = 2;
 force ace_repair_engineerSetting_repair = 2;
-ace_repair_engineerSetting_wheel = 0;
+force ace_repair_engineerSetting_wheel = 0;
 force ace_repair_fullRepairLocation = 3;
-ace_repair_fullRepairRequiredItems = ["ace_repair_anyToolKit"];
-ace_repair_locationsBoostTraining = false;
-ace_repair_miscRepairRequiredItems = ["ace_repair_anyToolKit"];
-ace_repair_miscRepairTime = 15;
-ace_repair_patchWheelEnabled = 0;
-ace_repair_patchWheelLocation = ["ground","vehicle"];
-ace_repair_patchWheelMaximumRepair = 0.3;
-ace_repair_patchWheelRequiredItems = ["ace_repair_anyToolKit"];
-ace_repair_patchWheelTime = 5;
+force ace_repair_fullRepairRequiredItems = ["ace_repair_anyToolKit"];
+force ace_repair_locationsBoostTraining = false;
+force ace_repair_miscRepairRequiredItems = ["ace_repair_anyToolKit"];
+force ace_repair_miscRepairTime = 15;
+force ace_repair_patchWheelEnabled = 0;
+force ace_repair_patchWheelLocation = ["ground","vehicle"];
+force ace_repair_patchWheelMaximumRepair = 0.3;
+force ace_repair_patchWheelRequiredItems = ["ace_repair_anyToolKit"];
+force ace_repair_patchWheelTime = 5;
 force ace_repair_repairDamageThreshold = 0.454115;
 force ace_repair_repairDamageThreshold_engineer = 0.550964;
-ace_repair_timeCoefficientFullRepair = 1.5;
-ace_repair_wheelChangeTime = 10;
-ace_repair_wheelRepairRequiredItems = [];
+force ace_repair_timeCoefficientFullRepair = 1.5;
+force ace_repair_wheelChangeTime = 10;
+force ace_repair_wheelRepairRequiredItems = [];
 
 // ACE Respawn
-ace_respawn_removeDeadBodiesDisconnected = true;
-ace_respawn_savePreDeathGear = false;
+force ace_respawn_removeDeadBodiesDisconnected = true;
+force ace_respawn_savePreDeathGear = false;
 
 // ACE Scopes
-ace_scopes_correctZeroing = true;
+force ace_scopes_correctZeroing = true;
 ace_scopes_deduceBarometricPressureFromTerrainAltitude = false;
 ace_scopes_defaultZeroRange = 100;
-ace_scopes_enabled = true;
+force ace_scopes_enabled = true;
 ace_scopes_forceUseOfAdjustmentTurrets = false;
 ace_scopes_overwriteZeroRange = false;
 ace_scopes_simplifiedZeroing = false;
@@ -488,19 +488,19 @@ ace_scopes_zeroReferenceTemperature = 15;
 acex_sitting_enable = true;
 
 // ACE Spectator
-ace_spectator_enableAI = false;
-ace_spectator_maxFollowDistance = 5;
-ace_spectator_restrictModes = 0;
-ace_spectator_restrictVisions = 0;
+force ace_spectator_enableAI = false;
+force ace_spectator_maxFollowDistance = 5;
+force ace_spectator_restrictModes = 0;
+force ace_spectator_restrictVisions = 0;
 
 // ACE Switch Units
-ace_switchunits_enableSafeZone = true;
-ace_switchunits_enableSwitchUnits = false;
-ace_switchunits_safeZoneRadius = 100;
-ace_switchunits_switchToCivilian = false;
-ace_switchunits_switchToEast = false;
-ace_switchunits_switchToIndependent = false;
-ace_switchunits_switchToWest = false;
+force ace_switchunits_enableSafeZone = false;
+force ace_switchunits_enableSwitchUnits = false;
+force ace_switchunits_safeZoneRadius = 0;
+force ace_switchunits_switchToCivilian = false;
+force ace_switchunits_switchToEast = false;
+force ace_switchunits_switchToIndependent = false;
+force ace_switchunits_switchToWest = false;
 
 // ACE Trenches
 force ace_trenches_bigEnvelopeDigDuration = 80;
@@ -509,7 +509,7 @@ force ace_trenches_smallEnvelopeDigDuration = 40;
 force ace_trenches_smallEnvelopeRemoveDuration = 40;
 
 // ACE Uncategorized
-ace_fastroping_autoAddFRIES = false;
+force ace_fastroping_autoAddFRIES = true;
 ace_fastroping_requireRopeItems = false;
 ace_gunbag_swapGunbagEnabled = true;
 ace_hitreactions_minDamageToTrigger = 0.1;
@@ -566,9 +566,9 @@ ace_ui_weaponNameBackground = true;
 ace_ui_zeroing = true;
 
 // ACE Vehicle Lock
-ace_vehiclelock_defaultLockpickStrength = 10;
-ace_vehiclelock_lockVehicleInventory = false;
-ace_vehiclelock_vehicleStartingLockState = -1;
+force ace_vehiclelock_defaultLockpickStrength = 10;
+force ace_vehiclelock_lockVehicleInventory = false;
+force ace_vehiclelock_vehicleStartingLockState = -1;
 
 // ACE Vehicles
 ace_novehicleclanlogo_enabled = false;
@@ -609,24 +609,24 @@ ace_reloadlaunchers_displayStatusText = true;
 ace_weaponselect_displayText = true;
 
 // ACE Weather
-ace_weather_enabled = true;
-ace_weather_showCheckAirTemperature = true;
-ace_weather_updateInterval = 60;
-ace_weather_windSimulation = true;
+force ace_weather_enabled = true;
+force ace_weather_showCheckAirTemperature = true;
+force ace_weather_updateInterval = 60;
+force ace_weather_windSimulation = true;
 
 // ACE Wind Deflection
-ace_winddeflection_enabled = true;
-ace_winddeflection_simulationInterval = 0.05;
-ace_winddeflection_vehicleEnabled = true;
+force ace_winddeflection_enabled = true;
+force ace_winddeflection_simulationInterval = 0.05;
+force ace_winddeflection_vehicleEnabled = true;
 
 // ACE Zeus
-ace_zeus_autoAddObjects = false;
-ace_zeus_canCreateZeus = -1;
-ace_zeus_radioOrdnance = false;
-ace_zeus_remoteWind = false;
-ace_zeus_revealMines = 0;
-ace_zeus_zeusAscension = false;
-ace_zeus_zeusBird = false;
+force ace_zeus_autoAddObjects = false;
+force ace_zeus_canCreateZeus = -1;
+force ace_zeus_radioOrdnance = false;
+force ace_zeus_remoteWind = false;
+force ace_zeus_revealMines = 0;
+force ace_zeus_zeusAscension = false;
+force ace_zeus_zeusBird = false;
 
 // ACRE2
 force acre_sys_core_automaticAntennaDirection = false;
@@ -685,9 +685,9 @@ acre_sys_list_SwitchChannelColor = [0.66,0.05,1,1];
 acre_sys_list_ToggleHeadsetColor = [0.66,0.05,1,1];
 
 // ACRE2 Zeus
-acre_sys_zeus_zeusCanSpectate = true;
-acre_sys_zeus_zeusCommunicateViaCamera = true;
-acre_sys_zeus_zeusDefaultVoiceSource = false;
+force acre_sys_zeus_zeusCanSpectate = true;
+force acre_sys_zeus_zeusCommunicateViaCamera = true;
+force acre_sys_zeus_zeusDefaultVoiceSource = false;
 
 // AIME Ammo Type Menu
 UPSL_aime_change_ammo_setting_ammo_class = true;
@@ -843,93 +843,93 @@ diwako_dui_radar_vehicleCompassEnabled = false;
 diwako_dui_use_layout_editor = false;
 
 // Dynamic Camo System
-DYNCAS_enabled = true;
-DYNCAS_ghillieReduction = 0.2;
-DYNCAS_lowerLimit = 0.6;
-DYNCAS_nightCompensation = 0.8;
-DYNCAS_targetList = 0;
-DYNCAS_updateFrequency = 1;
-DYNCAS_upperLimit = 1.4;
+force DYNCAS_enabled = true;
+force DYNCAS_ghillieReduction = 0.2;
+force DYNCAS_lowerLimit = 0.6;
+force DYNCAS_nightCompensation = 0.8;
+force DYNCAS_targetList = 0;
+force DYNCAS_updateFrequency = 1;
+force DYNCAS_upperLimit = 1.4;
 
 // Enhanced Movement Rework
-emr_main_allowClimbOnStandingUnits = false;
-emr_main_allowMidairClimbing = true;
-emr_main_animSpeedCoef = 1;
-emr_main_animSpeedStaminaCoef = 0.4;
-emr_main_assistDuty = 1.5;
-emr_main_assistHeight = 1;
-emr_main_blacklistStr = "";
-emr_main_climbingEnabled = true;
-emr_main_climbOnDuty = 3.4;
-emr_main_climbOverDuty = 3;
-emr_main_dropDuty = 0.7;
+force emr_main_allowClimbOnStandingUnits = false;
+force emr_main_allowMidairClimbing = true;
+force emr_main_animSpeedCoef = 1;
+force emr_main_animSpeedStaminaCoef = 0.4;
+force emr_main_assistDuty = 1.5;
+force emr_main_assistHeight = 1;
+force emr_main_blacklistStr = "";
+force emr_main_climbingEnabled = true;
+force emr_main_climbOnDuty = 3.4;
+force emr_main_climbOverDuty = 3;
+force emr_main_dropDuty = 0.7;
 emr_main_dropViewElevation = -0.7;
 emr_main_enableWalkableSurface = true;
-emr_main_enableWeightCheck = false;
+force emr_main_enableWeightCheck = false;
 emr_main_hintType = 2;
 emr_main_interactBehaviorInVehicle = "DISMOUNT";
-emr_main_jumpDuty = 1;
-emr_main_jumpForwardVelocity = 1.2;
-emr_main_jumpingEnabled = true;
-emr_main_jumpingLoadCoefficient = 1;
-emr_main_jumpVelocity = 3.5;
-emr_main_maxClimbHeight = 2.6;
-emr_main_maxDropHeight = 6;
-emr_main_maxWeightClimb1 = 100;
-emr_main_maxWeightClimb2 = 85;
-emr_main_maxWeightClimb3 = 60;
-emr_main_maxWeightJump = 100;
-emr_main_minClimbTerrain = 0.3;
+force emr_main_jumpDuty = 1;
+force emr_main_jumpForwardVelocity = 1.2;
+force emr_main_jumpingEnabled = true;
+force emr_main_jumpingLoadCoefficient = 1;
+force emr_main_jumpVelocity = 3.5;
+force emr_main_maxClimbHeight = 2.6;
+force emr_main_maxDropHeight = 6;
+force emr_main_maxWeightClimb1 = 100;
+force emr_main_maxWeightClimb2 = 85;
+force emr_main_maxWeightClimb3 = 60;
+force emr_main_maxWeightJump = 100;
+force emr_main_minClimbTerrain = 0.3;
 emr_main_preventHighVaulting = false;
-emr_main_staminaCoefficient = 1;
-emr_main_whitelistStr = "";
-emr_main_yeetCoefficient = 1.4;
+force emr_main_staminaCoefficient = 1;
+force emr_main_whitelistStr = "";
+force emr_main_yeetCoefficient = 1.4;
 
 // GRAD Trenches
-grad_trenches_functions_allowBigEnvelope = true;
-grad_trenches_functions_allowCamouflage = true;
-grad_trenches_functions_allowDigging = true;
-grad_trenches_functions_allowEffects = true;
-grad_trenches_functions_allowGiantEnvelope = true;
-grad_trenches_functions_allowHitDecay = true;
-grad_trenches_functions_allowLongEnvelope = true;
-grad_trenches_functions_allowShortEnvelope = true;
-grad_trenches_functions_allowSmallEnvelope = true;
-grad_trenches_functions_allowTextureLock = true;
-grad_trenches_functions_allowTrenchDecay = false;
-grad_trenches_functions_allowVehicleEnvelope = true;
-grad_trenches_functions_bigEnvelopeDamageMultiplier = 2;
-grad_trenches_functions_bigEnvelopeDigTime = 40;
-grad_trenches_functions_bigEnvelopeRemovalTime = -1;
-grad_trenches_functions_buildFatigueFactor = 1;
-grad_trenches_functions_camouflageRequireEntrenchmentTool = true;
-grad_trenches_functions_createTrenchMarker = false;
-grad_trenches_functions_decayTime = 1800;
-grad_trenches_functions_giantEnvelopeDamageMultiplier = 1;
-grad_trenches_functions_giantEnvelopeDigTime = 90;
-grad_trenches_functions_giantEnvelopeRemovalTime = -1;
-grad_trenches_functions_hitDecayMultiplier = 1;
-grad_trenches_functions_LongEnvelopeDigTime = 100;
-grad_trenches_functions_LongEnvelopeRemovalTime = -1;
-grad_trenches_functions_playersInAreaRadius = 0;
-grad_trenches_functions_shortEnvelopeDamageMultiplier = 2;
-grad_trenches_functions_shortEnvelopeDigTime = 15;
-grad_trenches_functions_shortEnvelopeRemovalTime = -1;
-grad_trenches_functions_smallEnvelopeDamageMultiplier = 3;
-grad_trenches_functions_smallEnvelopeDigTime = 30;
-grad_trenches_functions_smallEnvelopeRemovalTime = -1;
-grad_trenches_functions_stopBuildingAtFatigueMax = true;
-grad_trenches_functions_textureLockDistance = 5;
-grad_trenches_functions_timeoutToDecay = 7200;
-grad_trenches_functions_vehicleEnvelopeDamageMultiplier = 1;
-grad_trenches_functions_vehicleEnvelopeDigTime = 120;
-grad_trenches_functions_vehicleEnvelopeRemovalTime = -1;
-grad_trenches_functions_vehicleTrenchBuildSpeed = 5;
+force grad_trenches_functions_allowBigEnvelope = true;
+force grad_trenches_functions_allowCamouflage = true;
+force grad_trenches_functions_allowDigging = true;
+force grad_trenches_functions_allowEffects = true;
+force grad_trenches_functions_allowGiantEnvelope = true;
+force grad_trenches_functions_allowHitDecay = true;
+force grad_trenches_functions_allowLongEnvelope = true;
+force grad_trenches_functions_allowShortEnvelope = true;
+force grad_trenches_functions_allowSmallEnvelope = true;
+force grad_trenches_functions_allowTextureLock = true;
+force grad_trenches_functions_allowTrenchDecay = false;
+force grad_trenches_functions_allowVehicleEnvelope = true;
+force grad_trenches_functions_bigEnvelopeDamageMultiplier = 2;
+force grad_trenches_functions_bigEnvelopeDigTime = 40;
+force grad_trenches_functions_bigEnvelopeRemovalTime = -1;
+force grad_trenches_functions_buildFatigueFactor = 1;
+force grad_trenches_functions_camouflageRequireEntrenchmentTool = true;
+force grad_trenches_functions_createTrenchMarker = false;
+force grad_trenches_functions_decayTime = 1800;
+force grad_trenches_functions_giantEnvelopeDamageMultiplier = 1;
+force grad_trenches_functions_giantEnvelopeDigTime = 90;
+force grad_trenches_functions_giantEnvelopeRemovalTime = -1;
+force grad_trenches_functions_hitDecayMultiplier = 1;
+force grad_trenches_functions_LongEnvelopeDigTime = 100;
+force grad_trenches_functions_LongEnvelopeRemovalTime = -1;
+force grad_trenches_functions_playersInAreaRadius = 0;
+force grad_trenches_functions_shortEnvelopeDamageMultiplier = 2;
+force grad_trenches_functions_shortEnvelopeDigTime = 15;
+force grad_trenches_functions_shortEnvelopeRemovalTime = -1;
+force grad_trenches_functions_smallEnvelopeDamageMultiplier = 3;
+force grad_trenches_functions_smallEnvelopeDigTime = 30;
+force grad_trenches_functions_smallEnvelopeRemovalTime = -1;
+force grad_trenches_functions_stopBuildingAtFatigueMax = true;
+force grad_trenches_functions_textureLockDistance = 5;
+force grad_trenches_functions_timeoutToDecay = 7200;
+force grad_trenches_functions_vehicleEnvelopeDamageMultiplier = 1;
+force grad_trenches_functions_vehicleEnvelopeDigTime = 120;
+force grad_trenches_functions_vehicleEnvelopeRemovalTime = -1;
+force grad_trenches_functions_vehicleTrenchBuildSpeed = 5;
 
 // GreenMag
-greenmag_main_CBAS_enable = true;
+force greenmag_main_CBAS_enable = true;
 greenmag_main_CBAS_maxMags = 0;
-greenmag_main_CBAS_simpleGM = true;
+force greenmag_main_CBAS_simpleGM = true;
 
 // LAMBS Danger
 force lambs_danger_cqbRange = 60;
@@ -977,14 +977,24 @@ force lambs_main_radioShout = 100;
 force lambs_main_radioWest = 200;
 
 // Laxemann Align
-L_Align_enabled = true;
-L_Align_steadyShake_enabled = true;
+force L_Align_enabled = true;
+force L_Align_steadyShake_enabled = true;
 
 // Laxemann Immerse
-L_Immerse_exShake = true;
-L_Immerse_force = true;
-L_Immerse_recoil = true;
-L_Immerse_twitch = true;
+force L_Immerse_exShake = true;
+force L_Immerse_force = true;
+force L_Immerse_recoil = true;
+force L_Immerse_twitch = true;
+
+// Reeveli's User Marker System
+Rev_marker_briefing = false;
+Rev_marker_CBA = false;
+Rev_marker_command = false;
+Rev_marker_global = false;
+Rev_marker_group = false;
+Rev_marker_side = false;
+Rev_marker_vehicle = false;
+Rev_markers_direct = false;
 
 // SSD Death Screams
 force SSD_DS_enable_death = true;
@@ -1006,13 +1016,13 @@ force SSD_DS_r_stomach = 0.8;
 
 // TSP Animate
 force tsp_cba_animate_door = true;
-tsp_cba_animate_dynamicReadyBush = true;
-tsp_cba_animate_dynamicReadyFriend = 3;
-tsp_cba_animate_dynamicReadyFriendAngle = 35;
-tsp_cba_animate_dynamicReadyObject = 2;
+force tsp_cba_animate_dynamicReadyBush = false;
+force tsp_cba_animate_dynamicReadyFriend = 3;
+force tsp_cba_animate_dynamicReadyFriendAngle = 35;
+force tsp_cba_animate_dynamicReadyObject = 2;
 force tsp_cba_animate_dynamicReadyPoll = 0;
-tsp_cba_animate_dynamicReadyVertical = -0.1;
-tsp_cba_animate_friendsAreObjects = false;
+force tsp_cba_animate_dynamicReadyVertical = -0.1;
+force tsp_cba_animate_friendsAreObjects = false;
 force tsp_cba_animate_map = true;
 force tsp_cba_animate_nvg = true;
 tsp_cba_animate_walk = false;
@@ -1024,12 +1034,12 @@ zen_camera_adaptiveSpeed = true;
 zen_camera_defaultSpeedCoef = 1;
 zen_camera_fastSpeedCoef = 1;
 zen_camera_followTerrain = true;
-zen_common_ascensionMessages = false;
+force zen_common_ascensionMessages = false;
 force zen_common_autoAddObjects = true;
-zen_common_cameraBird = false;
+force zen_common_cameraBird = false;
 force zen_common_darkMode = false;
-zen_common_disableGearAnim = false;
-zen_common_preferredArsenal = 1;
+force zen_common_disableGearAnim = true;
+force zen_common_preferredArsenal = 1;
 zen_compat_ace_hideModules = true;
 zen_context_menu_enabled = 2;
 zen_context_menu_overrideWaypoints = false;
@@ -1043,7 +1053,7 @@ zen_editor_previews_enabled = true;
 zen_editor_randomizeCopyPaste = false;
 zen_editor_removeWatermark = true;
 zen_editor_unitRadioMessages = 0;
-zen_placement_enabled = false;
+force zen_placement_enabled = false;
 zen_remote_control_cameraExitPosition = 2;
 zen_visibility_enabled = 0;
 zen_visibility_maxDistance = 5000;


### PR DESCRIPTION
I noticed a lot of settings that should be forced on the client were not. These include configuration settings such as ACE Ballistics calculations, advanced fatigue enablement, cookoff settings, dragging and carrying settings, shrapnel and spalling calculations, and other general configuration data.

Since forcing these settings and updating them, I have no longer been able to observe a bug that was consistently occurring where you would shoot an AI and they would freeze. I believe this was due to a conflict in ballistic calculations as they were different between the mission and the client. 

Anything that is preference or performance related was left as a client side setting.

I've tested these settings on the latest mission (PL2) and they are working, as I didn't change many values just if they should be forced on the client or not.

Values that were changed were to settings that we do not want to have on and are now forced off in the client side. 

Auto_Add_Fries was changed to true, this is for fast roping. 