### PR TITLE
added functions/kill_counter.sqf

### DIFF
--- a/functions/kill_counter.sqf
+++ b/functions/kill_counter.sqf
@@ -1,0 +1,8 @@
+{
+	systemChat format [
+		"%1 got %2 kills",
+		name _x,
+                         (getPlayerScores _x) select 0
+	];
+} forEach allPlayers;
+systemChat format ["%1 total kills", scoreSide west];


### PR DESCRIPTION
Added the function used to output kills for each connected player, and total kills for the entire blue side in the chat. Recommend having this as an action on an item, I used Land_vn_noticeboard_f and on the init of the object had the following:

this addAction ["Total kills", "functions\kill_counter.sqf"]

This means when returning to the bar at the end of the operation, the script can be triggered. Alternatively it can be triggered directly by a logged in admin via the script interface. Could be a Zeus module in future, however will be prioritising other things for now as triggering the script directly via admin interface works fine with a global execute.