### PR TITLE
Event handler to set ai skill

### DIFF
--- a/functions/init_columbia_setAiSkills.sqf
+++ b/functions/init_columbia_setAiSkills.sqf
@@ -9,11 +9,9 @@
 
 if (!isServer) exitWith {};
 
-systemChat format ["script successfully started"];
-
 [
 	"O_Soldier_base_F", "Init", { 	
-		
+
 		params ["_unit"];
 		
 		[{

--- a/functions/init_columbia_setAiSkills.sqf
+++ b/functions/init_columbia_setAiSkills.sqf
@@ -1,0 +1,24 @@
+/*
+ *
+ * Set general AI skill. Could be expanded to set specific skill values later. Currently only works on AI spawned during the game - all AI spawned in the editor retain their pre-set skills.
+ *
+ * https://cbateam.github.io/CBA_A3/docs/files/xeh/fnc_addClassEventHandler-sqf.html
+ * https://cbateam.github.io/CBA_A3/docs/files/common/fnc_execNextFrame-sqf.html
+ *
+ */
+
+if (!isServer) exitWith {};
+
+systemChat format ["script successfully started"];
+
+[
+	"O_Soldier_base_F", "Init", { 	
+		
+		params ["_unit"];
+		
+		[{
+				params ["_unit"];
+				_unit setSkill 0.33;
+		}, [_unit]] call CBA_fnc_execNextFrame;										
+
+}, true, [], true] call CBA_fnc_addClassEventHandler;

--- a/functions/init_columbia_setAiSkills.sqf
+++ b/functions/init_columbia_setAiSkills.sqf
@@ -7,16 +7,26 @@
  *
  */
 
-if (!isServer) exitWith {};
+//if (!isServer) exitWith {};
 
 [
 	"O_Soldier_base_F", "Init", { 	
 
 		params ["_unit"];
-		
+
 		[{
 				params ["_unit"];
-				_unit setSkill 0.33;
+				_unit setSkill ["general", 0.33];
+				_unit setSkill ["aimingAccuracy", 0.33];
+				_unit setSkill ["aimingSpeed", 0.33];
+				_unit setSkill ["endurance", 0.33];
+				_unit setSkill ["spotTime", 0.10];
+				_unit setSkill ["courage", 0.33];
+				_unit setSkill ["aimingShake", 0.33];
+				_unit setSkill ["commanding", 0.33];
+				_unit setSkill ["spotDistance", 0.10];
+				_unit setSkill ["reloadSpeed", 0.33];
+
 		}, [_unit]] call CBA_fnc_execNextFrame;										
 
 }, true, [], true] call CBA_fnc_addClassEventHandler;

--- a/functions/init_columbia_setAiSkills.sqf
+++ b/functions/init_columbia_setAiSkills.sqf
@@ -7,7 +7,7 @@
  *
  */
 
-//if (!isServer) exitWith {};
+if (!isServer) exitWith {};
 
 [
 	"O_Soldier_base_F", "Init", { 	

--- a/init.sqf
+++ b/init.sqf
@@ -65,3 +65,6 @@ execVM "functions\init_columbia_removeThrowables.sqf";
 
 // init convertMedicKit on killed units
 execVM "functions\columbia_fn_FirstAidconvertACE.sqf";
+
+// init setAiSkills on all spawned units
+execVM "functions\init_columbia_setAiSkills.sqf";


### PR DESCRIPTION
first version (mostly a proof of concept) for setting individual AI skills when spawned by Zeus. This gives us a lot more freedom to dictate how strong the AI is in specific regards. Currently just sets the general skill to .33 but can be used to set individual skills as per https://community.bistudio.com/wiki/Arma_3:_AI_Skill