### PR TITLE
shorted-ace-cookoff-duration

### DIFF
--- a/default/defaultAddons.txt
+++ b/default/defaultAddons.txt
@@ -80,7 +80,7 @@ ace_common_settingProgressBarLocation = 0;
 force ace_common_swayFactor = 1;
 
 // ACE Cook off
-force ace_cookoff_ammoCookoffDuration = 1;
+force ace_cookoff_ammoCookoffDuration = 0.1;
 force ace_cookoff_destroyVehicleAfterCookoff = false;
 force ace_cookoff_enable = 2;
 force ace_cookoff_enableAmmobox = true;


### PR DESCRIPTION
Shortened ACE cookoff duration to shortest value. Testing with this value of 0.1 a truck full off guns and ammo took around 45 seconds to fully cookoff. With the previous setting of 1 it was still cooking off at 2 minutes.