### PR TITLE
change-description.ext-and-addon-settings

### DIFF
--- a/default/defaultAddons.txt
+++ b/default/defaultAddons.txt
@@ -489,9 +489,9 @@ acex_sitting_enable = true;
 
 // ACE Spectator
 force ace_spectator_enableAI = false;
-force ace_spectator_maxFollowDistance = 5;
-force ace_spectator_restrictModes = 0;
-force ace_spectator_restrictVisions = 0;
+force ace_spectator_maxFollowDistance = 10;
+force ace_spectator_restrictModes = 1;
+force ace_spectator_restrictVisions = 3;
 
 // ACE Switch Units
 force ace_switchunits_enableSafeZone = false;

--- a/description.ext
+++ b/description.ext
@@ -2,7 +2,7 @@
 loadScreen = "images\col-new-logo-no-bg.paa";
 author = "";
 onLoadName = "";    // Title of the mission
-onLoadMission = "Welcome To  MACV SOG - Columbia";
+onLoadMission = "Welcome to MACV SOG - Columbia";
 briefingName 	= "Mission selection menu name";
 enabledebugconsole = 1;
 
@@ -10,10 +10,10 @@ enabledebugconsole = 1;
 respawn = 3;            // Respawn "BASE", use 'respawn_west'  
 respawnOnStart = -1;    // No respawn on mission start
 respawnDialog = 0;      // Show scoreboard, 0 = Disabled, 1 = Enabled
-respawnDelay = 10;      // Delay in seconds
+respawnDelay = 60;      // Delay in seconds
 respawnButton = 1;      // 0 = Disabled, 1 = Enabled
 
-respawnTemplates[] = {"Counter"};
+respawnTemplates[] = {"Wave", "ace_spectator", "Counter"};
 
 //Corpsemanager
 corpseManagerMode = 3;


### PR DESCRIPTION
changed respawns to be wave based with one minute timer. Maximum wait time for a respawn is two minutes. When waiting for respawn players can spectate friendly players in third or first person. Freecam and spectating AI is disallowed. 

Wave based respawns should increase cohesion and result in less disorganisation upon multiple casualties. Timer may be increased in future but we will see.

Fixed double space in description.ext and corrected capitalisation. 