### PR TITLE
initial-check-for-gs

### DIFF
--- a/functions/CBASettings.sqf
+++ b/functions/CBASettings.sqf
@@ -64,6 +64,7 @@
 ["Columbia_CBA_triangulation_signal_strength_3", "SLIDER", ["Threshold distance for signal strength 3/5"], [CBA_SETTINGS_COLUMBIA, "Triangulation"], [0, 5000, 3000, 0], 1, {}, false] call CBA_fnc_addSetting;
 ["Columbia_CBA_triangulation_signal_strength_4", "SLIDER", ["Threshold distance for signal strength 4/5"], [CBA_SETTINGS_COLUMBIA, "Triangulation"], [0, 5000, 2000, 0], 1, {}, false] call CBA_fnc_addSetting;
 ["Columbia_CBA_triangulation_signal_strength_5", "SLIDER", ["Threshold distance for signal strength 5/5"], [CBA_SETTINGS_COLUMBIA, "Triangulation"], [0, 5000, 1000, 0], 1, {}, false] call CBA_fnc_addSetting;
+["Columbia_CBA_trilateration_require_spike", "CHECKBOX", ["Trilateration requires spike"], [CBA_SETTINGS_COLUMBIA, "Triangulation"],true, 1, {}, true] call CBA_fnc_addSetting;
 
 // Traps
 ["Columbia_CBA_traps_mace_kill_radius", "SLIDER", ["Mace kill radius (m)"], [CBA_SETTINGS_COLUMBIA, "Traps"], [1, 10, 3, 0], 1, {}, false] call CBA_fnc_addSetting;

--- a/functions/TRIANGULATE/columbia_triangulate_signal.sqf
+++ b/functions/TRIANGULATE/columbia_triangulate_signal.sqf
@@ -9,10 +9,13 @@ if (_current_time_seconds < _next_triangulation_time_seconds) exitWith
     hint format ["Cool down : %1 seconds", round _cool_down];
 };
 
-If (_nearest_acre_spike > 10) exitWith //If there isn't a radio spike within 10m, returns a hint to tell the user there is no spike nearby. Does not trigger the cooldown period.
-{
-    hint format ["No ground spike nearby"];
-};
+
+If( Columbia_CBA_trilateration_require_spike = true, 
+    If (_nearest_acre_spike > 10) exitWith //If there isn't a radio spike within 10m, returns a hint to tell the user there is no spike nearby. Does not trigger the cooldown period.
+        {
+            hint format ["No ground spike nearby"];
+        };
+)
 
 LAST_TRIANGULATION_TIME_SECONDS = _current_time_seconds;
 publicVariable "LAST_TRIANGULATION_TIME_SECONDS";

--- a/functions/TRIANGULATE/columbia_triangulate_signal.sqf
+++ b/functions/TRIANGULATE/columbia_triangulate_signal.sqf
@@ -9,13 +9,10 @@ if (_current_time_seconds < _next_triangulation_time_seconds) exitWith
     hint format ["Cool down : %1 seconds", round _cool_down];
 };
 
-
-If( Columbia_CBA_trilateration_require_spike = true, 
-    If (_nearest_acre_spike > 10) exitWith //If there isn't a radio spike within 10m, returns a hint to tell the user there is no spike nearby. Does not trigger the cooldown period.
-        {
-            hint format ["No ground spike nearby"];
-        };
-)
+if (_nearest_acre_spike > 10 && Columbia_CBA_trilateration_require_spike == true) exitWith //If there isn't a radio spike within 10m, returns a hint to tell the user there is no spike nearby. Does not trigger the cooldown period.
+{
+    hint format ["No ground spike nearby"];
+};
 
 LAST_TRIANGULATION_TIME_SECONDS = _current_time_seconds;
 publicVariable "LAST_TRIANGULATION_TIME_SECONDS";

--- a/functions/TRIANGULATE/columbia_triangulate_signal.sqf
+++ b/functions/TRIANGULATE/columbia_triangulate_signal.sqf
@@ -1,10 +1,17 @@
 // 5 minutes timeout between each call.
 private _next_triangulation_time_seconds = LAST_TRIANGULATION_TIME_SECONDS + Columbia_CBA_triangulation_cool_down;
 private _current_time_seconds = serverTime;
+private _nearest_acre_spike = player distance nearestObject [player, "vhf30108spike"]; //Gets the distances to the nearest radio spike
+
 if (_current_time_seconds < _next_triangulation_time_seconds) exitWith
 {
     private _cool_down = abs (_current_time_seconds - _next_triangulation_time_seconds);
     hint format ["Cool down : %1 seconds", round _cool_down];
+};
+
+If (_nearest_acre_spike > 10) exitWith //If there isn't a radio spike within 10m, returns a hint to tell the user there is no spike nearby. Does not trigger the cooldown period.
+{
+    hint format ["No ground spike nearby"];
 };
 
 LAST_TRIANGULATION_TIME_SECONDS = _current_time_seconds;


### PR DESCRIPTION
adds a simple check to the triangulation script to see if there is a GS nearby (class name "vhf30108spike").