### PR TITLE
removed-prox-claymores

### DIFF
--- a/default/loadouts/default_rifleman.json
+++ b/default/loadouts/default_rifleman.json
@@ -92,11 +92,6 @@
                     1
                 ],
                 [
-                    "vn_mine_m18_range_mag",
-                    2,
-                    1
-                ],
-                [
                     "vn_mine_m14_mag",
                     6,
                     1


### PR DESCRIPTION
noticed reserves still had access to prox claymores in default loadout which we removed on account of their often blowing up immediately upon placement