### PR TITLE
radio battery audio cue

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,8 +454,7 @@ You will have two new action under 'ace equipment' interaction:
 - "Show battery level": If you have one of the above radio types in your inventory.
 - "Add new battery": If you have one of the above radio types and a battery item in your inventory.
 
-If your battery is **EMPTY**, the radio will be turned OFF (will not update radio GUI) and once a new battery has been added, 
-you will have to turn it OFF/ON again in the radio GUI.
+If your battery is **EMPTY**, the radio will be turned OFF and once a new battery has been added it will be turned ON again automatically.
 
 </details>
 

--- a/functions/battery/fn_batteryManager.sqf
+++ b/functions/battery/fn_batteryManager.sqf
@@ -99,6 +99,14 @@ _increaseBatteryLevelPrc77 = [
 
             // If radio call threshold reached, spawn enemy towards current player position and reset.
             [player] call COLSOG_fnc_incrementRadioCallsCounter;
+
+            // If battery critically low, then 3 bip audio cue to warn about low battery.
+            private _batteryLevelInPercent = round (100 * (_newBatteryLevelInSeconds/colsog_battery_prc77Capacity));
+            if ((_batteryLevelInPercent > 0) AND (_batteryLevelInPercent <= 20)) then
+            {
+                playSound "gdtmod_satchel_starttimer"; // (bip bip bip)
+                hintSilent format ["Critical: [#----]"];
+            };
         };
     }
 ] call CBA_fnc_addEventHandler;

--- a/functions/battery/fn_increaseBatteryLevel.sqf
+++ b/functions/battery/fn_increaseBatteryLevel.sqf
@@ -19,12 +19,14 @@ if (isNil "_batteryLevelInSeconds") then
     hint format ["Battery Initialized"];
 } else {
     scopeName "outsideOfLoop";
+    private _radioId = [_radioType, _player] call acre_api_fnc_getRadioByType;
     private _powerItemRemoved = "MISSING";
     {
         if ([_player, _x] call BIS_fnc_hasItem) then
         {
             _powerItemRemoved = _x;
             _player removeItem _powerItemRemoved;
+            [_radioId, "setOnOffState", 1, true] call acre_sys_data_fnc_dataEvent;
             breakTo "outsideOfLoop";
         };
     } forEach colsog_battery_powerItems;


### PR DESCRIPTION
- If battery critically low, then 3 bip audio cue to warn about low battery.
- When battery empty and new one added, radio will be switch ON automatically.