### PR TITLE
True kill counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,7 +618,7 @@ To add an action to display kill counter for each player on the server, add the 
 this addAction ["Display total kills", "functions\colsog_fn_killCounter.sqf"]
 ```
 
-this will give you a scroll wheel action to diplay the kill counter when looking at the object. see [colsog_fn_killCounter.sqf](https://github.com/gerard-sog/arma3-macvsog-columbia-scripts/blob/main/functions/colsog_fn_killCounter.sqf)
+this will give you a scroll wheel action to display the kill counter when looking at the object. see [colsog_fn_killCounter.sqf](https://github.com/gerard-sog/arma3-macvsog-columbia-scripts/blob/main/functions/colsog_fn_killCounter.sqf)
 
 </details>
 

--- a/functions/colsog_fn_countTotalAIDeaths.sqf
+++ b/functions/colsog_fn_countTotalAIDeaths.sqf
@@ -3,6 +3,5 @@ totalAIDeaths = 0;
 ["O_Soldier_base_F", "Killed", 
 {
 	totalAIDeaths = totalAIDeaths + 1;
-	systemChat str totalAIDeaths
 }
 , true, [], true] call CBA_fnc_addClassEventHandler;

--- a/functions/colsog_fn_countTotalAIDeaths.sqf
+++ b/functions/colsog_fn_countTotalAIDeaths.sqf
@@ -1,3 +1,4 @@
+if (!isServer) exitWith {};
 totalAIDeaths = 0;
 
 ["O_Soldier_base_F", "Killed", 

--- a/functions/colsog_fn_countTotalAIDeaths.sqf
+++ b/functions/colsog_fn_countTotalAIDeaths.sqf
@@ -1,0 +1,8 @@
+totalAIDeaths = 0;
+
+["O_Soldier_base_F", "Killed", 
+{
+	totalAIDeaths = totalAIDeaths + 1;
+	systemChat str totalAIDeaths
+}
+, true, [], true] call CBA_fnc_addClassEventHandler;

--- a/functions/colsog_fn_killCounter.sqf
+++ b/functions/colsog_fn_killCounter.sqf
@@ -1,1 +1,2 @@
+//Broadcasts the true number of kills made by blufor. This is calculated in the colsog_fn_countTotalAIDeaths.sqf script.
 ["RT Columbia inflicted " + str totalAIDeaths + " casualties on the enemy."] remoteExec ["systemChat"];

--- a/functions/colsog_fn_killCounter.sqf
+++ b/functions/colsog_fn_killCounter.sqf
@@ -1,8 +1,1 @@
-{
-	systemChat format [
-		"%1 got %2 kills",
-		name _x,
-                         (getPlayerScores _x) select 0
-	];
-} forEach allPlayers;
-systemChat format ["%1 total kills", scoreSide west];
+["RT Columbia inflicted " + str totalAIDeaths + " casualties on the enemy."] remoteExec ["systemChat"];

--- a/functions/colsog_fn_killCounter.sqf
+++ b/functions/colsog_fn_killCounter.sqf
@@ -1,2 +1,2 @@
 //Broadcasts the true number of kills made by blufor. This is calculated in the colsog_fn_countTotalAIDeaths.sqf script.
-["RT Columbia inflicted " + str totalAIDeaths + " casualties on the enemy."] remoteExec ["systemChat"];
+["RT Columbia and air assets inflicted " + str totalAIDeaths + " casualties on the enemy."] remoteExec ["systemChat"];

--- a/init.sqf
+++ b/init.sqf
@@ -57,6 +57,9 @@ execVM "functions\init_colsog_removeThrowables.sqf";
 // init convertMedicKit on killed units
 execVM "functions\colsog_fn_firstAidConvertAce.sqf";
 
+// init OnDeath AI event handler
+execVM "functions\colsog_fn_countTotalAIDeaths.sqf";
+
 // run the script to create the nice vectored map borders
 // commented out by default as currently we only have borders for Cam Lao Nam
 // [] spawn compileScript ["vet_border\init.sqf"];


### PR DESCRIPTION
- Added a new event handler - on death of any AI, a kill counter is incremented. This catches all deaths, including those not reflected by the scoreboard. In my testing many kills were not reflected, mostly related to explosives including but not limited to frag grenades, willie pete grenades and rockets.
- Updated the colsog_fn_killCounter script to make use of this new variable
- Removed the old kill counter script on the TV as this was not accurate as it did not count many grenades including WP and fragmentation, as well as air support

Overall the script is now simpler and more accurate, unfortunately does not have individual kills listed anymore but as this was not accurate at all I don't think it is fair to keep in to those who have specific weapons e.g. GL or aerial assets.