### PR TITLE
updated-loadouts

### DIFF
--- a/default/loadouts/Grenadier.json
+++ b/default/loadouts/Grenadier.json
@@ -26,7 +26,7 @@
       ""
     ],
     [
-      "vn_b_uniform_macv_04_06",
+      "vn_b_uniform_macv_01_04",
       [
         [
           "vn_m1911_mag",
@@ -96,10 +96,6 @@
           1
         ],
         [
-          "greenmag_beltlinked_762x39_basic_100",
-          1
-        ],
-        [
           "grad_paceCountBeads_functions_paceCountBeads",
           1
         ],
@@ -148,6 +144,11 @@
           1
         ],
         [
+          "pk_762_39_100Rnd_belt",
+          1,
+          100
+        ],
+        [
           [
             "vn_sten",
             "vn_s_sten",
@@ -164,7 +165,7 @@
         ]
       ]
     ],
-    "vn_b_boonie_02_08",
+    "vn_b_boonie_02_04",
     "",
     [
       "vn_m19_binocs_grn",

--- a/default/loadouts/MG_RPD.json
+++ b/default/loadouts/MG_RPD.json
@@ -15,12 +15,8 @@
         [],
         [],
         [
-            "vn_b_uniform_macv_04_06",
+            "vn_b_uniform_macv_01_04",
             [
-                [
-                    "greenmag_item_speedloader",
-                    1
-                ],
                 [
                     "vn_m67_grenade_mag",
                     2,
@@ -84,10 +80,6 @@
                     1
                 ],
                 [
-                    "greenmag_beltlinked_762x39_basic_100",
-                    3
-                ],
-                [
                     "grad_paceCountBeads_functions_paceCountBeads",
                     1
                 ],
@@ -122,7 +114,7 @@
                 ]
             ]
         ],
-        "vn_b_boonie_02_08",
+        "vn_b_boonie_02_04",
         "",
         [
             "vn_m19_binocs_grn",

--- a/default/loadouts/Medic.json
+++ b/default/loadouts/Medic.json
@@ -15,7 +15,7 @@
     [],
     [],
     [
-      "vn_b_uniform_macv_04_06",
+      "vn_b_uniform_macv_01_04",
       [
         [
           "murshun_cigs_cigpack",
@@ -48,14 +48,6 @@
       "vn_b_pack_trp_02",
       [
         [
-          "ACE_fieldDressing",
-          15
-        ],
-        [
-          "ACE_quikclot",
-          15
-        ],
-        [
           "ACE_epinephrine",
           2
         ],
@@ -69,11 +61,11 @@
         ],
         [
           "ACE_elasticBandage",
-          15
+          25
         ],
         [
           "ACE_packingBandage",
-          15
+          25
         ],
         [
           "ACE_salineIV_500",
@@ -104,12 +96,16 @@
           1
         ],
         [
-          "greenmag_beltlinked_762x39_basic_100",
+          "grad_paceCountBeads_functions_paceCountBeads",
           1
         ],
         [
-          "grad_paceCountBeads_functions_paceCountBeads",
-          1
+          "ACE_quikclot",
+          5
+        ],
+        [
+          "ACE_fieldDressing",
+          5
         ],
         [
           "vn_m34_grenade_mag",
@@ -122,18 +118,18 @@
           1
         ],
         [
-          "DemoCharge_Remote_Mag",
-          1,
-          1
-        ],
-        [
           "vn_m18_white_mag",
           2,
           1
+        ],
+        [
+          "pk_762_39_100Rnd_belt",
+          1,
+          100
         ]
       ]
     ],
-    "vn_b_boonie_02_08",
+    "vn_b_boonie_02_04",
     "",
     [
       "vn_m19_binocs_grn",

--- a/default/loadouts/Pointman_AK.json
+++ b/default/loadouts/Pointman_AK.json
@@ -15,12 +15,8 @@
     [],
     [],
     [
-      "vn_b_uniform_macv_04_06",
+      "vn_b_uniform_macv_01_04",
       [
-        [
-          "greenmag_item_speedloader",
-          1
-        ],
         [
           "murshun_cigs_cigpack",
           1,
@@ -87,10 +83,6 @@
           1
         ],
         [
-          "greenmag_beltlinked_762x39_basic_100",
-          1
-        ],
-        [
           "grad_paceCountBeads_functions_paceCountBeads",
           1
         ],
@@ -127,6 +119,11 @@
           "vn_m18_white_mag",
           2,
           1
+        ],
+        [
+          "pk_762_39_100Rnd_belt",
+          1,
+          100
         ]
       ]
     ],

--- a/default/loadouts/RTO.json
+++ b/default/loadouts/RTO.json
@@ -26,7 +26,7 @@
     ],
     [],
     [
-      "vn_b_uniform_macv_04_06",
+      "vn_b_uniform_macv_01_04",
       [
         [
           "ACE_splint",
@@ -109,11 +109,11 @@
           1
         ],
         [
-          "ACRE_PRC77",
+          "ACE_salineIV_500",
           1
         ],
         [
-          "ACE_salineIV_500",
+          "ACRE_PRC77",
           1
         ],
         [
@@ -153,7 +153,7 @@
         ]
       ]
     ],
-    "vn_b_boonie_02_08",
+    "vn_b_boonie_02_04",
     "",
     [
       "vn_m19_binocs_grn",
@@ -173,5 +173,10 @@
       ""
     ]
   ],
-  []
+  [
+    [
+      "ace_earplugs",
+      true
+    ]
+  ]
 ]

--- a/default/loadouts/default_rifleman.json
+++ b/default/loadouts/default_rifleman.json
@@ -15,12 +15,8 @@
         [],
         [],
         [
-            "vn_b_uniform_macv_04_06",
+            "vn_b_uniform_macv_01_04",
             [
-                [
-                    "greenmag_item_speedloader",
-                    1
-                ],
                 [
                     "murshun_cigs_cigpack",
                     1,
@@ -129,10 +125,15 @@
                     "vn_m18_white_mag",
                     2,
                     1
+                ],
+                [
+                    "pk_762_39_100Rnd_belt",
+                    1,
+                    100
                 ]
             ]
         ],
-        "vn_b_boonie_02_08",
+        "vn_b_boonie_02_04",
         "",
         [
             "vn_m19_binocs_grn",

--- a/default/loadouts/squad_leader.json
+++ b/default/loadouts/squad_leader.json
@@ -15,7 +15,7 @@
     [],
     [],
     [
-      "vn_b_uniform_macv_04_06",
+      "vn_b_uniform_macv_01_04",
       [
         [
           "murshun_cigs_cigpack",
@@ -84,19 +84,11 @@
           1
         ],
         [
-          "greenmag_beltlinked_762x39_basic_100",
-          1
-        ],
-        [
           "ACE_morphine",
           2
         ],
         [
           "ACE_salineIV_500",
-          1
-        ],
-        [
-          "greenmag_item_speedloader",
           1
         ],
         [
@@ -143,10 +135,15 @@
           "vn_m18_white_mag",
           2,
           1
+        ],
+        [
+          "pk_762_39_100Rnd_belt",
+          1,
+          100
         ]
       ]
     ],
-    "vn_b_boonie_02_08",
+    "vn_b_boonie_02_04",
     "",
     [
       "vn_m19_binocs_grn",


### PR DESCRIPTION
Updated all loadouts to have 100 round PK belts for the RPD 
Changed all loadouts to use spray camo by default as I believe this was more common and just been waiting for a good opportunity to change it
Medic has had some bandage rebalancing (less basic and quick clot, more elastic and packing)
RTO lost demo block by default to make space for MG ammo (more important)
For some reason the RTO was the only loadout without the ACE earplugs section at the bottom, so when it got auto-added I left it for consistencies sake. Has no impact on the other loadouts which have it