### PR TITLE
changed-length-and-disabled-simulation

### DIFF
--- a/functions/stabo/colsog_fn_dropStabo.sqf
+++ b/functions/stabo/colsog_fn_dropStabo.sqf
@@ -45,4 +45,6 @@ _parentHelicopter setVariable ["COLSOG_staboRope", _staboRope, true];
 	false															// Show in unconscious state
 ] remoteExec ["BIS_fnc_holdActionAdd", 0]; // no need for JIP parameter in remoteExec
 
+//There needs to be a sleep here, otherwise the physics of the rope falling causes some latent movement in the sandbag.
+sleep 1;
 _droppedSandbag enableSimulation false;

--- a/functions/stabo/colsog_fn_dropStabo.sqf
+++ b/functions/stabo/colsog_fn_dropStabo.sqf
@@ -17,8 +17,8 @@ _droppedSandbag setVariable ["COLSOG_staboParentHelicopter", _parentHelicopter, 
 // store the sandbag created on parent helicopter (broadcast needed might be another player detaching)
 _parentHelicopter setVariable ["COLSOG_staboSandbag", _droppedSandbag, true];
 
-// Creates a rope under vehicle 55m in length with 50 segments (dropped sandbag attached at end of rope).
-private _staboRope = ropeCreate [_parentHelicopter, [0, 0, 0], _droppedSandbag, [0,0,0], 50, nil, nil, nil, 63];
+// Creates a rope under vehicle 100m in length with 63 segments (dropped sandbag attached at end of rope).
+private _staboRope = ropeCreate [_parentHelicopter, [0, 0, 0], _droppedSandbag, [0,0,0], 100, nil, nil, nil, 63];
 
 // store the rope created on parent helicopter (broadcast needed might be another player detaching)
 _parentHelicopter setVariable ["COLSOG_staboRope", _staboRope, true];
@@ -44,3 +44,5 @@ _parentHelicopter setVariable ["COLSOG_staboRope", _staboRope, true];
 	false,															// Remove on completion (removes for allPlayers !)
 	false															// Show in unconscious state
 ] remoteExec ["BIS_fnc_holdActionAdd", 0]; // no need for JIP parameter in remoteExec
+
+_droppedSandbag enableSimulation false;


### PR DESCRIPTION
increased the length of the STABO rope to 100m - this makes it less sensitive to pilot movements and the average height of foliage on Vanam is around 50m, so the previous height did not allow for much play

Also disabled simulation on the sandbag as dropped - for some reason it does not stop the sandbag moving but does hugely decrease its movement speed - to be demoed this weekend