### PR TITLE
Update editable objects

### DIFF
--- a/functions/environment/colsog_zeus_lowFog.sqf
+++ b/functions/environment/colsog_zeus_lowFog.sqf
@@ -21,7 +21,7 @@ private _onConfirm = {
 	_helipad setPosATL _heliPosition;
 
 	[[_helipad, _mainColor], "functions\environment\colsog_fn_lowFog.sqf"] remoteExec ["execVM", 0, true];
-	["zen_common_addObjects", [[_helipad]]] call CBA_fnc_serverEvent;
+	["zen_common_updateEditableObjects", [[_helipad], true]] call CBA_fnc_serverEvent;
 
 };
 

--- a/functions/environment/colsog_zeus_ringFog.sqf
+++ b/functions/environment/colsog_zeus_ringFog.sqf
@@ -21,7 +21,7 @@ private _onConfirm = {
 	_helipad setVariable ["AL_high_ON", true, true]; // still setting a variable on object created, could be used to delete all at once
 
 	[[_helipad, _mainColor], "functions\environment\colsog_fn_highFog.sqf"] remoteExec ["execVM", 0, true];
-	["zen_common_addObjects", [[_helipad]]] call CBA_fnc_serverEvent;
+	["zen_common_updateEditableObjects", [[_helipad], true]] call CBA_fnc_serverEvent;
 
 };
 

--- a/functions/resupply/colsog_zeus_createResupplyBox.sqf
+++ b/functions/resupply/colsog_zeus_createResupplyBox.sqf
@@ -17,6 +17,7 @@ clearItemCargoGlobal _supplyBox;
 clearWeaponCargoGlobal _supplyBox;
 clearMagazineCargoGlobal _supplyBox;
 clearBackpackCargoGlobal _supplyBox;
+["zen_common_updateEditableObjects", [[_supplyBox], true]] call CBA_fnc_serverEvent;
 
 private _contentAsArrayOfArrays = [];
 for "_i" from 0 to (((count colsog_supply_content) / 2) - 1) do

--- a/functions/sensors/engine/fn_createEngineSensor.sqf
+++ b/functions/sensors/engine/fn_createEngineSensor.sqf
@@ -22,6 +22,7 @@ if ((isNil "_sensor") && (isNil "_sensorId")) then
 {
     player removeItem colsog_sensor_engineInventoryItem;
     _sensor = createVehicle [colsog_sensor_engineThingItem, getPosATL player, [], 0.5, "CAN_COLLIDE"];
+    ["zen_common_updateEditableObjects", [[_sensor], true]] call CBA_fnc_serverEvent;
 
     // Giving an idea to log it in records, this will give the ability to differentiate them.
     COLSOG_sensorIdCounter = COLSOG_sensorIdCounter + 1;

--- a/functions/sensors/gravity/fn_createGravitySensor.sqf
+++ b/functions/sensors/gravity/fn_createGravitySensor.sqf
@@ -6,6 +6,8 @@ private _sensor = createVehicle [colsog_sensor_gravityThingItem, _pos, [], 5, "C
 // Drops it towards the ground.
 _sensor setVelocity [0, 0, -5];
 
+["zen_common_updateEditableObjects", [[_sensor], true]] call CBA_fnc_serverEvent;
+
 // Giving an idea to log it in records, this will give the ability to differentiate them.
 COLSOG_sensorIdCounter = COLSOG_sensorIdCounter + 1;
 _sensor setVariable ["COLSOG_sensorID", COLSOG_sensorIdCounter, true];

--- a/functions/sensors/gunshot/fn_createGunshotSensor.sqf
+++ b/functions/sensors/gunshot/fn_createGunshotSensor.sqf
@@ -22,6 +22,7 @@ if ((isNil "_sensor") && (isNil "_sensorId")) then
 {
     player removeItem colsog_sensor_gunshotInventoryItem;
     _sensor = createVehicle [colsog_sensor_gunshotThingItem, getPosATL player, [], 0.5, "CAN_COLLIDE"];
+    ["zen_common_updateEditableObjects", [[_sensor], true]] call CBA_fnc_serverEvent;
 
     // Giving an idea to log it in records, this will give the ability to differentiate them.
     COLSOG_sensorIdCounter = COLSOG_sensorIdCounter + 1;


### PR DESCRIPTION
Zeus enhanced  has changed CBA_serverevent name for displaying objects in zeus interface:
* changed for fogs
* added for re-supply box & sensors

Need to talk about it for traps, which object you want displayed (maybe one tied to the trigger so all can be delete if you delete de the displayed object)

Will add later for new stabo & climb