### PR TITLE
add-lighter-and-akm

### DIFF
--- a/default/arsenals/defaultWhitelistArsenal.json
+++ b/default/arsenals/defaultWhitelistArsenal.json
@@ -1209,5 +1209,7 @@
   "vnx_m77e_buck_mag",
   "vnx_m77e_fl_mag",
   "vnx_m77e_so_mag",
-  "vnx_gjet_mag"
+  "vnx_gjet_mag",
+  "arifle_AKM_F",
+  "uns_item_zippo"
 ]


### PR DESCRIPTION
add ak that was previously in the arsenal + unsung lighter for burning huts