### PR TITLE
added-update-to-radio-installation-module

### DIFF
--- a/functions/colsog_zeus_initPf77Rack.sqf
+++ b/functions/colsog_zeus_initPf77Rack.sqf
@@ -29,6 +29,14 @@ if !(isNil "_isRadioInitialized") exitWith {
     playSound "FD_Start_F";
 };
 
+//_this call acre_api_fnc_removeAllRacksFromVehicle
+
+// Removes all pre-existing racks from the vehicle. This stage also forces the initialization of the radios, even if no-one has entered the vehicle since it spawned. 
+[_object] remoteExec ["acre_api_fnc_removeAllRacksFromVehicle"];
+
+// There needs to be a second delay to resolve a race condition between the removal function and the adding functions below. 
+sleep 1; 
+
 [_object, ["ACRE_VRC64", "A2A", "PRC77", false, ["inside"], [], "ACRE_PRC77", [], [] ], false] remoteExec ["acre_api_fnc_addRackToVehicle", 2];
 [_object, ["ACRE_VRC64", "A2G", "PRC77", false, ["inside"], [], "ACRE_PRC77", [], [] ], false] remoteExec ["acre_api_fnc_addRackToVehicle", 2];
 [_object, ["ACRE_VRC64", "HQ", "PRC77", false, ["inside"], [], "ACRE_PRC77", [], [] ], false] remoteExec ["acre_api_fnc_addRackToVehicle", 2];

--- a/functions/colsog_zeus_initPf77Rack.sqf
+++ b/functions/colsog_zeus_initPf77Rack.sqf
@@ -30,7 +30,7 @@ if !(isNil "_isRadioInitialized") exitWith {
 };
 
 // Removes all pre-existing racks from the vehicle. This stage also forces the initialization of the radios, even if no-one has entered the vehicle since it spawned. 
-[_object] remoteExec ["acre_api_fnc_removeAllRacksFromVehicle"];
+[_object] remoteExec ["acre_api_fnc_removeAllRacksFromVehicle", 2];
 
 // There needs to be a second delay to resolve a race condition between the removal function and the adding functions below. 
 sleep 1; 

--- a/functions/colsog_zeus_initPf77Rack.sqf
+++ b/functions/colsog_zeus_initPf77Rack.sqf
@@ -29,8 +29,6 @@ if !(isNil "_isRadioInitialized") exitWith {
     playSound "FD_Start_F";
 };
 
-//_this call acre_api_fnc_removeAllRacksFromVehicle
-
 // Removes all pre-existing racks from the vehicle. This stage also forces the initialization of the radios, even if no-one has entered the vehicle since it spawned. 
 [_object] remoteExec ["acre_api_fnc_removeAllRacksFromVehicle"];
 


### PR DESCRIPTION
Added an extra line to remove all default racks from vehicles. 

The 2 main benefits of doing this:

- This forces the initialisation of radios even if no-one has entered the vehicle. No more bricking the vehicle if you forget to go into it before installing radios
- Unifies radio experience across all airframes. All airframes will have the same three radios. Maybe not as IRL but for our purposes very useful.

Serves as a proof of concept for being able to turn this into an event handler in the future, to save Zeus having to do anything. 

We could remove the variables that check if the radios have already been installed as well, as the removal will prevent duplicate racks, but left in for now as it is useful for Zeus to be able to check if they have done a vehicle all ready. 