### PR TITLE
Hatg update

### DIFF
--- a/default/defaultAddons.txt
+++ b/default/defaultAddons.txt
@@ -1117,7 +1117,7 @@ force hatg_setting_mp_ai = false;
 force hatg_setting_reveal_nearby = false;
 force hatg_setting_simple = false;
 force hatg_setting_simple_object = false;
-force hatg_setting_surfaces = true;
+force hatg_setting_surfaces = false;
 
 // Hide Among The Grass -  Equipment
 force hatg_setting_equipment_ghillie_blacklist = "[]";


### PR DESCRIPTION
Played around with the hide amongst the grass settings. Based on gameplay testing these represented a positive change

- remove requirement to be on "grass" (as I'm not sure if the various jungle terrain we play on counts)
- remove the shot cooldown setting. This means you could take a shot and become hidden again if you move behind shrubbery straight away. This produces a more realistic behaviour in the AI
- remove hard coded minimum spotting distance. 
- forced some settings which were not forced

I've found this provides a more realistic gameplay especially during the initial engagement (if we get the first shot we have a bigger advantage as we are not guaranteed revealed for 10 seconds) and during a disengagement (if we move back to crouch, the AI will not be able to see us again through the foliage. This causes them to push up to attempt to re-acquire us and reduces instances of being shot through foliage)

However, especially when in combat mode, the AI will still be able to find you as their spotting is much higher once they've been engaged. So you are not just invisible to the AI if you stay in a bush.

I'm looking at making a fork of this mod as right now all of these settings only apply when crouching and I'd like them to apply when standing. This would enable us to move when standing which is more realistic. 

Can be discussed at upcoming meeting