### PR TITLE
Battery update

### DIFF
--- a/default/defaultAddons.txt
+++ b/default/defaultAddons.txt
@@ -802,7 +802,8 @@ force colsog_supply_content = "[
       'pk_9_19_50Rnd_box', 5,
       'pk_carbine_10Rnd_clip', 5,
       'pk_45ACP_10Rnd_clip', 5,
-      'pk_792_57_50Rnd_belt', 5
+      'pk_792_57_50Rnd_belt', 5,
+      'colsog_inv_prc77_battery', 2
     ]";
 
 // COLSOG Miscellaneous
@@ -838,7 +839,7 @@ force colsog_tracker_moduleName = "TrackermoduleNAME";
 force colsog_battery_enemySpawnThreshold = 100;
 force colsog_battery_groupsTriggeringEnemySpawnThresholdIncrease = "";
 force colsog_battery_powerItems = "colsog_inv_prc77_battery";
-force colsog_battery_prc77Capacity = 900;
+force colsog_battery_prc77Capacity = 2700;
 force colsog_battery_refreshRate = 2;
 force colsog_triangulation_coolDown = 150;
 force colsog_triangulation_itemsToDetect = "vn_o_prop_t884_01,vn_o_prop_t102e_01";

--- a/functions/CBASettings.sqf
+++ b/functions/CBASettings.sqf
@@ -156,7 +156,7 @@
 
 // Battery
 ["colsog_battery_refreshRate", "SLIDER", ["Battery state refresh rate (seconds)"], [CBA_SETTINGS_COLSOG_RADIO_AND_BATTERY, "Battery"], [0, 5, 5, 0], 1, {}, false] call CBA_fnc_addSetting;
-["colsog_battery_prc77Capacity", "SLIDER", ["PRC77 Battery capacity in seconds"], [CBA_SETTINGS_COLSOG_RADIO_AND_BATTERY, "Battery"], [0, 1800, 900, 0], 1, {}, false] call CBA_fnc_addSetting;
+["colsog_battery_prc77Capacity", "SLIDER", ["PRC77 Battery capacity in seconds"], [CBA_SETTINGS_COLSOG_RADIO_AND_BATTERY, "Battery"], [0, 7200, 900, 0], 1, {}, false] call CBA_fnc_addSetting;
 ["colsog_battery_enemySpawnThreshold", "SLIDER", ["Amount of radio calls before enemy detection"], [CBA_SETTINGS_COLSOG_RADIO_AND_BATTERY, "Battery"], [0, 100, 50, 0], 1, {}, false] call CBA_fnc_addSetting;
 ["colsog_battery_groupsTriggeringEnemySpawnThresholdIncrease", "EDITBOX", ["Groups impacted by enemy radio call detection"], [CBA_SETTINGS_COLSOG_RADIO_AND_BATTERY, "Battery"], "Columbia,Reserves", 1, {colsog_battery_groupsTriggeringEnemySpawnThresholdIncrease = colsog_battery_groupsTriggeringEnemySpawnThresholdIncrease splitString " " joinString "" splitString ","}, false] call CBA_fnc_addSetting;
 ["colsog_battery_powerItems", "EDITBOX", ["Item used as spare battery"], [CBA_SETTINGS_COLSOG_RADIO_AND_BATTERY, "Battery"], "ACE_UAVBattery", 1, {colsog_battery_powerItems = colsog_battery_powerItems splitString " " joinString "" splitString ","}, false] call CBA_fnc_addSetting;


### PR DESCRIPTION
Added battery to resupply
Increased limit on CBA battery settings to maximum of 2 hours 
Changed battery life to 45 mins (whilst this is a lot it will give us the best indicator for if its a good amount for implementing talk multiplier)